### PR TITLE
Allow arrays to be reallocated

### DIFF
--- a/Interpreter.cpp
+++ b/Interpreter.cpp
@@ -477,7 +477,7 @@ void Interpreter::doALLOT(Interpreter *iptr)
 	}
 	else
 	{
-		cerr << "\nError: The array \"" << arrayName.text << "\" already exists.\n";
+		iptr->symTab[arrayName.text].reallocate(size.value);
 	}
 }
 

--- a/Symbol.cpp
+++ b/Symbol.cpp
@@ -1,4 +1,5 @@
 #include <list>
+#include <algorithm>
 #include "Symbol.h"
 
 using namespace std;
@@ -127,4 +128,20 @@ Types Symbol::getType()
 int Symbol::getValue()
 {
 	return value;
+}
+
+void Symbol::reallocate(const int newSize)
+{
+	int* newArray = new int[newSize];
+	if (array != nullptr)
+	{
+		int smallerSize = min(value, newSize);
+		for (int i = 0; i < smallerSize; i++)
+		{
+			newArray[i] = array[i];
+		}
+		delete[] array;
+		array = newArray;
+		value = newSize;
+	}
 }

--- a/Symbol.h
+++ b/Symbol.h
@@ -42,6 +42,11 @@ public:
 
 	int getValue();
 
+	//Reallocates space for an array after if ALLOT is called again. Keeps items
+	//already in the array (as long as they don't get truncated with a smaller
+	//size).
+	void reallocate(const int newSize);
+
 private:
 	//Determines if this symbol is a keyword/operator, variable, or an array.
 	Types type;


### PR DESCRIPTION
Arrays can be resized by calling ALLOT on an existing array. If the new size
is larger, all items will be copied over. If it is smaller, extra items will be
truncated.